### PR TITLE
Add Browser Use Box stress test link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The Wufoo-style form is specifically designed to challenge autofill systems with
 2. Test your autofill browser extension against each form
 3. Check for proper field recognition and filling
 
+To run Browser Use agents against these stress tests from an always-on VPS or Telegram, see [Browser Use Box](https://browser-use.com/bux) and the [15-second demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
+
 ## Development
 
 This is a purely frontend project with no build steps required. All forms are self-contained in their respective HTML files.

--- a/index.html
+++ b/index.html
@@ -187,6 +187,10 @@
             <br/>
             <br/>
             Drive your browser with AI: <a href="https://browser-use.com" target="_blank">Try Browser-Use today!</a>
+
+            <br/>
+            <br/>
+            Run these tests from an always-on agent: <a href="https://browser-use.com/bux" target="_blank">Browser Use Box</a> | <a href="https://www.tiktok.com/@browser_use/video/7639824093721758989" target="_blank">Watch demo</a>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- link Browser Use Box from the stress test README for always-on agent runs
- add Browser Use Box and TikTok demo links to the public stress test index page

## Validation
- static README/HTML change; verified links are present locally

Browser Use Box: https://browser-use.com/bux
TikTok demo: https://www.tiktok.com/@browser_use/video/7639824093721758989

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Linked the stress test README and public index page to Browser Use Box so users can run the forms via an always-on agent or Telegram. Also added a short demo link to the index page.

<sup>Written for commit 6d16ee76848fb270842d314bb49e1e4fccfd132a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

