### PR TITLE
Revert "Add Browser Use Box stress test link"

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ The Wufoo-style form is specifically designed to challenge autofill systems with
 2. Test your autofill browser extension against each form
 3. Check for proper field recognition and filling
 
-To run Browser Use agents against these stress tests from an always-on VPS or Telegram, see [Browser Use Box](https://browser-use.com/bux) and the [15-second demo](https://www.tiktok.com/@browser_use/video/7639824093721758989).
-
 ## Development
 
 This is a purely frontend project with no build steps required. All forms are self-contained in their respective HTML files.

--- a/index.html
+++ b/index.html
@@ -187,10 +187,6 @@
             <br/>
             <br/>
             Drive your browser with AI: <a href="https://browser-use.com" target="_blank">Try Browser-Use today!</a>
-
-            <br/>
-            <br/>
-            Run these tests from an always-on agent: <a href="https://browser-use.com/bux" target="_blank">Browser Use Box</a> | <a href="https://www.tiktok.com/@browser_use/video/7639824093721758989" target="_blank">Watch demo</a>
         </div>
     </div>
 


### PR DESCRIPTION
Reverts browser-use/stress-tests#25

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the previously added external promo links by removing the `Browser Use Box` and TikTok demo links from README and index.html. Keeps the stress tests self-contained and avoids outbound marketing links.

<sup>Written for commit 6462932dfde804fb6080174224b7465ff737fe8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

